### PR TITLE
Implement simple blog generator agents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+Logs/
+__pycache__/

--- a/Agent.py
+++ b/Agent.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass, field
+from logging.handlers import RotatingFileHandler
+from pathlib import Path
+
+from agents import Agent as OpenAiAgent, Runner, set_default_openai_client
+from openai import AsyncAzureOpenAI
+
+
+LOG_PATH = Path("Logs/agent.log")
+LOG_PATH.parent.mkdir(exist_ok=True)
+
+_logger = logging.getLogger(__name__)
+_logger.setLevel(logging.INFO)
+if not _logger.handlers:
+    handler = RotatingFileHandler(LOG_PATH, maxBytes=1_000_000, backupCount=3)
+    formatter = logging.Formatter(
+        "%(asctime)s [%(levelname)s] %(name)s: %(message)s"
+    )
+    handler.setFormatter(formatter)
+    _logger.addHandler(handler)
+
+
+@dataclass
+class Agent:
+    """Coordinates multiple OpenAI agents to generate and proofread a blog."""
+
+    outline_agent: OpenAiAgent = field(init=False)
+    content_agent: OpenAiAgent = field(init=False)
+    proofread_agent: OpenAiAgent = field(init=False)
+
+    def __post_init__(self) -> None:
+        if "OPENAI_API_VERSION" not in os.environ and "AZURE_OPENAI_API_VERSION" in os.environ:
+            os.environ["OPENAI_API_VERSION"] = os.environ["AZURE_OPENAI_API_VERSION"]
+
+        set_default_openai_client(AsyncAzureOpenAI())
+
+        self.outline_agent = OpenAiAgent(
+            name="Outline Writer",
+            instructions=(
+                "Create a concise outline with headings and bullet points for the given blog title."
+            ),
+        )
+
+        self.content_agent = OpenAiAgent(
+            name="Content Writer",
+            instructions=(
+                "Expand the outline into a full Markdown blog post. If corrections are provided, apply them."
+            ),
+        )
+
+        self.proofread_agent = OpenAiAgent(
+            name="Proofread Writer",
+            instructions=(
+                "Review the blog content and return a numbered list of corrections to make."
+            ),
+        )
+
+    def run(self, title: str) -> str:
+        """Generate and proofread content for ``title``."""
+
+        _logger.info("Generating outline")
+        outline_result = Runner.run_sync(self.outline_agent, title)
+        outline = outline_result.final_output
+
+        _logger.info("Writing content")
+        content_result = Runner.run_sync(self.content_agent, outline)
+        content = content_result.final_output
+
+        _logger.info("Proofreading content")
+        feedback_result = Runner.run_sync(self.proofread_agent, content)
+        feedback = feedback_result.final_output
+
+        _logger.info("Applying corrections")
+        corrected_result = Runner.run_sync(
+            self.content_agent,
+            (
+                "Please update the blog post with these corrections:\n"
+                f"{feedback}\n\nBlog post:\n{content}"
+            ),
+        )
+        return corrected_result.final_output

--- a/UnitTests/test_agent.py
+++ b/UnitTests/test_agent.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import pytest
+
+from Agent import Agent
+
+
+class DummyResult:
+    def __init__(self, output: str) -> None:
+        self.final_output = output
+
+
+def test_agent_pipeline_runs(monkeypatch: pytest.MonkeyPatch) -> None:
+    blog_agent = Agent()
+
+    call_order: list[str] = []
+
+    def fake_run_sync(agent, input_text):
+        call_order.append(agent.name)
+        if agent.name == "Outline Writer":
+            return DummyResult("Outline")
+        if agent.name == "Content Writer" and len(call_order) == 2:
+            return DummyResult("Draft content")
+        if agent.name == "Proofread Writer":
+            return DummyResult("Fix typos")
+        return DummyResult("Corrected content")
+
+    monkeypatch.setattr("agents.Runner.run_sync", fake_run_sync)
+    monkeypatch.setattr("agents.set_default_openai_client", lambda *args, **kwargs: None)
+
+    result = blog_agent.run("Some Title")
+    assert result == "Corrected content"
+    assert call_order == [
+        "Outline Writer",
+        "Content Writer",
+        "Proofread Writer",
+        "Content Writer",
+    ]

--- a/main.py
+++ b/main.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from Agent import Agent
+
+
+def configure_logging() -> None:
+    log_dir = Path("Logs")
+    log_dir.mkdir(exist_ok=True)
+    handler = logging.handlers.RotatingFileHandler(
+        log_dir / "runtime.log", maxBytes=1_000_000, backupCount=3
+    )
+    formatter = logging.Formatter(
+        "%(asctime)s [%(levelname)s] %(name)s: %(message)s"
+    )
+    handler.setFormatter(formatter)
+    root_logger = logging.getLogger()
+    root_logger.setLevel(logging.INFO)
+    if not root_logger.handlers:
+        root_logger.addHandler(handler)
+
+
+def main() -> None:
+    configure_logging()
+    blog_agent = Agent()
+    title = "The Future of AI Collaboration"
+    result = blog_agent.run(title)
+    print(result)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add Agent class orchestrating Outline, Content, and Proofread agents
- provide entry point in `main.py`
- create unit test for the agent pipeline
- ignore Logs directory

## Testing
- `ruff check .`
- `mypy .`
- `pytest UnitTests/ -q`
- `python main.py`

------
https://chatgpt.com/codex/tasks/task_e_68632e056d10832096bed289f4c8b1d4